### PR TITLE
Changed -fabi-version=6 to Linux only

### DIFF
--- a/configure
+++ b/configure
@@ -88,7 +88,7 @@ DEBUG=""
 
 LIBNAME=""
 
-CXXFLAGS="-std=c++11 -fabi-version=6 -Wall -I. -I$SRCDIR/include"
+CXXFLAGS="-std=c++11 -Wall -I. -I$SRCDIR/include"
 LDFLAGS=""
 SOFLAGS="-shared"
 DEPLIBS="fftw3f"
@@ -171,7 +171,7 @@ case "$TARGET_OS" in
         ;;
     *linux*)
         LIBNAME="libdfttest.so"
-        CXXFLAGS="$CXXFLAGS -fPIC"
+        CXXFLAGS="$CXXFLAGS -fabi-version=6 -fPIC"
         SOFLAGS="$SOFLAGS -fPIC"
         ;;
     *)


### PR DESCRIPTION
Made the -fabi-version=6 flag to be a Linux only since clang in OSX does not have fabi-version.

Fixes #4.
